### PR TITLE
[add]shipping&validates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,6 @@ gem 'font-awesome-sass','~>5.13'
 gem "refile", require: "refile/rails", github: 'manfe/refile'
 gem "refile-mini_magick"
 gem "kaminari"
+
+#エラーメッセージを日本語に変換してくれるgem
+gem 'rails-i18n', '~> 5.1' 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.6)
       actionpack (= 5.2.6)
       activesupport (= 5.2.6)
@@ -290,6 +293,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.6)
+  rails-i18n (~> 5.1)
   refile!
   refile-mini_magick
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/customers/shipping_addresses.coffee
+++ b/app/assets/javascripts/customers/shipping_addresses.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/customers/shipping_addresses.scss
+++ b/app/assets/stylesheets/customers/shipping_addresses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the customers/shipping_addresses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/error_message.scss
+++ b/app/assets/stylesheets/error_message.scss
@@ -1,0 +1,7 @@
+.alert {
+    color:#262626; 
+    background:#FFEBE8;
+    text-align: left;
+    border:2px solid #990000;
+    padding:px; font-weight:850;
+  }

--- a/app/controllers/customers/shipping_addresses_controller.rb
+++ b/app/controllers/customers/shipping_addresses_controller.rb
@@ -1,0 +1,42 @@
+class Customers::ShippingAddressesController < ApplicationController
+    
+def index
+    @shipping_address_new = ShippingAddress.new
+    @shipping_addresses = current_customer.shipping_addresses
+end
+
+def create
+    @shipping_address_new = ShippingAddress.new(shipping_params)
+    @shipping_address_new.customer_id = current_customer.id
+    if @shipping_address_new.save
+       redirect_to shipping_addresses_path
+    else
+       @shipping_addresses = current_customer.shipping_addresses
+       render :index
+    end
+end
+
+def edit
+    @shipping_address = ShippingAddress.find(params[:id])
+end
+
+def update
+    @shipping_address = ShippingAddress.find(params[:id])
+    @shipping_address.update(shipping_params)
+    redirect_to shipping_addresses_path
+end
+
+
+def destroy
+    @shipping_address = ShippingAddress.find(params[:id])
+    @shipping_address.destroy
+    redirect_to shipping_addresses_path
+end
+
+private
+
+def shipping_params
+    params.require(:shipping_address).permit(:name, :postcode, :address)
+end
+
+end

--- a/app/helpers/customers/shipping_addresses_helper.rb
+++ b/app/helpers/customers/shipping_addresses_helper.rb
@@ -1,0 +1,2 @@
+module Customers::ShippingAddressesHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -12,5 +12,16 @@ class Customer < ApplicationRecord
   has_many :cart_products, dependent: :destroy
   
   has_many :orders, dependent: :destroy
+  has_many :shipping_addresses, dependent: :destroy
+  
+  
+  validates :last_name, presence: true
+  validates :first_name, presence: true
+  validates :last_name_kana, presence: true
+  validates :first_name_kana, presence: true
+  validates :postcode, presence: true
+  validates :address, presence: true
+  validates :phone_number, presence: true
+  
   
 end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,2 +1,8 @@
 class ShippingAddress < ApplicationRecord
+    belongs_to :customer
+    
+   
+    validates :postcode, presence: true
+    validates :address, presence: true
+    validates :name, presence: true
 end

--- a/app/views/customers/registrations/new.html.erb
+++ b/app/views/customers/registrations/new.html.erb
@@ -7,7 +7,7 @@
       <h2 class="mb-5 login-color col-3 text-center">新規会員登録</h2>
 
         <%= form_for(resource, as: resource_name, url: customer_registration_path) do |f| %>
-          <%= render "customers/shared/error_messages", resource: resource %>
+          <%= render 'layouts/error_message', model: f.object %>
           
           <div class="field mb-1">
             <%= f.label :"名前　　　　　　　　　　　(姓)", class: 'col-3' %>

--- a/app/views/customers/sessions/new.html.erb
+++ b/app/views/customers/sessions/new.html.erb
@@ -6,7 +6,7 @@
       <h4 class="mt-5 mb-4 ml-4 col-4 text-center login-color">会員の方はこちらからログイン</h4>
 
         <%= form_for(resource, as: resource_name, url: customer_session_path) do |f| %>
-          <%= render "customers/shared/error_messages", resource: resource %>
+          <%= render 'layouts/error_message', model: f.object %>
         
         
           <div class="field mb-1">

--- a/app/views/customers/shipping_addresses/edit.html.erb
+++ b/app/views/customers/shipping_addresses/edit.html.erb
@@ -1,0 +1,28 @@
+<body>
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+          <h2 class="mb-5 login-color col-3 text-center">配送先登録/一覧</h2>
+          
+          <%= form_with model:@shipping_address, url: shipping_address_path, local:true do |f| %>
+          
+          <div class="field mb-1">
+            <%= f.label :"郵便番号(ハイフンなし)", class: 'col-3' %>
+            <%= f.text_field :postcode, autofocus: true, class: 'rounded', placeholder: "0000000" %>
+          </div>
+          
+          <div class="field mb-1">
+            <%= f.label :"住所", class: 'col-3' %>
+            <%= f.text_field :address, autofocus: true, class: 'rounded col-5', placeholder: "東京都渋谷区代々木神園町0-0" %>
+          </div>
+          
+          <div class="field mb-1">
+            <%= f.label :"宛名", class: 'col-3' %>
+            <%= f.text_field :name, autofocus: true, class: 'rounded', placeholder: "令和道子" %>
+            <%= f.submit "変更内容を保存", class: 'btn btn-success col-2 offset-3' %>
+          </div>
+          <% end %>
+      </div>
+    </div>
+  </div>
+</body>

--- a/app/views/customers/shipping_addresses/index.html.erb
+++ b/app/views/customers/shipping_addresses/index.html.erb
@@ -1,0 +1,51 @@
+<body>
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+          <h2 class="mb-5 login-color col-3 text-center">配送先登録/一覧</h2>
+          
+          
+          <%= form_with model:@shipping_address_new, url: shipping_addresses_path, local:true do |f| %>
+          <%= render 'layouts/error_message', model: f.object %>
+          <div class="field mb-1">
+            <%= f.label :"郵便番号(ハイフンなし)", class: 'col-3' %>
+            <%= f.text_field :postcode, autofocus: true, class: 'rounded', placeholder: "0000000" %>
+          </div>
+          
+          <div class="field mb-1">
+            <%= f.label :"住所", class: 'col-3' %>
+            <%= f.text_field :address, autofocus: true, class: 'rounded col-5', placeholder: "東京都渋谷区代々木神園町0-0" %>
+          </div>
+          
+          <div class="field mb-1">
+            <%= f.label :"宛名", class: 'col-3' %>
+            <%= f.text_field :name, autofocus: true, class: 'rounded', placeholder: "令和道子" %>
+            <%= f.submit "新規登録", class: 'btn btn-success col-2 offset-3' %>
+          </div>
+          <% end %>
+          
+          
+          <table class="table table-bordered border-dark col-9 mt-5 mb-5">
+            <thead>
+              <tr>
+                  <th class="table-active">郵便番号</th>
+                  <th class="table-active col-5">住所</th>
+                  <th class="table-active">宛名</th>
+                  <th class="table-active"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @shipping_addresses.each do |shipping_address| %>
+              <tr>
+                  <td><%= shipping_address.postcode %></td>
+                  <td><%= shipping_address.address %></td>
+                  <td><%= shipping_address.name %></td>
+                  <td><%= link_to "編集する", edit_shipping_address_path(shipping_address) ,class: "btn btn-success btn-sm" %>　<%= link_to "削除する", shipping_address_path(shipping_address) , method: :delete ,class: "btn btn-danger btn-sm","data-confirm" => "このままだと消しちゃうぞ♡" %></td>
+              </tr>
+              <% end %>
+            </tbody>
+          </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/app/views/layouts/_error_message.html.erb
+++ b/app/views/layouts/_error_message.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class="alert alert-warning">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+
+
 require_relative 'boot'
 
 require 'rails/all'
@@ -15,5 +17,17 @@ module NaganoCake
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    
+    # デフォルトのlocaleを日本語(:ja)にする
+    config.i18n.default_locale = :ja
+    
+    
+     #　#　以下の記述を追記する(設定必須)
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    
+    
+    
   end
+  
+  
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,29 @@
+
+ja:
+  activerecord:
+    # モデル名
+    models:
+      shipping_address: 
+      customer: 
+    # モデルごとの属性
+    attributes:
+      shipping_address:
+        postcode: 郵便番号 #変換後の日本語を記入
+        address: 住所 #変換後の日本語を記入
+        name: 宛名 #変換後の日本語を記入
+      
+      customer:
+        last_name: 「入力する時ここの欄チェックした?笑」名前の(姓)
+        first_name: ここ空白はありえないって〜、名前の(名)
+        last_name_kana: 苗字のカナ
+        first_name_kana: 下の名前のカナ
+        postcode: 郵便番号
+        address: 決して悪用はしないので住所
+        phone_number: あなた美しいですね、よければ携帯番号
+        password: 忘れてますよ、パスワード
+        email: メールアドレス
+      
+  # 全モデル共通の属性
+  attributes:
+    created_at: 作成日時
+    updated_at: 更新日時

--- a/test/controllers/customers/shipping_addresses_controller_test.rb
+++ b/test/controllers/customers/shipping_addresses_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Customers::ShippingAddressesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#shipping_addressページのindex,editページ作成しました
- 編集、削除、新規作成の動作確認済みです
#validatesを日本語表記に変えるgemを追加して、sign_upページ、
　shipping_addressのindexに日本語のエラーメッセージ出るようにしました
https://qiita.com/d0ne1s/items/89846ebe97c9114865ca
- エラーメッセージ後の配列が崩れてしまいます。
- 直し方を検索しましたが、見つけれなかったので直せる方いたらお願いします。
- 配列崩れるだけなので、エラーにはなりません！
- gem追加したので、pullした後bundle installお願いします。